### PR TITLE
Add Nick to Weka standup captain rotation

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -44,7 +44,7 @@ Remember, there is only 2-3 minutes for each person - your job is to keep them o
 module.exports = [
   {
     name: 'weka',
-    standupCaptains: ['libbyschuknight', 'timothyjohn2015', 'fourseven', 'eileen', 'dave', 'nat', 'charlotte' ],
+    standupCaptains: ['libbyschuknight', 'timothyjohn2015', 'fourseven', 'eileen', 'dave', 'nat', 'charlotte', 'StoryparkNick'],
     captainDayExceptions: {
       2: ['eileen'],
       4: ['eileen', 'charlotte'],

--- a/src/shared/users.js
+++ b/src/shared/users.js
@@ -8,6 +8,7 @@ module.exports.users = {
   AlexQuinlivan: '<@U08R7BSLR>', // Alex
   AaronThornton00: '<@U048FJY1K>', // Aaron
   'Rob-Bee-Neilson': '<@UPE3KH494>', // Robbie
+  StoryparkNick: '<@U03TVGDFWF9>', // Nick
 
   // These ones aren't github usernames because these people aren't on github:
   katie: '<@U01KA1D3G78>', // Katie


### PR DESCRIPTION
Added myself to `users.js` and the weka `standupCaptains`.

Wasn't sure if there's a good way to test this one, I tried running `arc sandbox` locally but couldn't figure out how to test scheduled jobs, and directly loading the module doesn't work due to the use of `architect/shared` for imports.

Should be fairly low risk in any case.